### PR TITLE
Enable hiding the sidebar

### DIFF
--- a/vemos-extension/app/components/frame-styles.hbs
+++ b/vemos-extension/app/components/frame-styles.hbs
@@ -4,6 +4,7 @@
       transform: translate(0, 0);
       width: 90vw;
       height: 100vh;
+      transition: width 200ms ease;
     }
 
     #vemos-container {
@@ -13,7 +14,18 @@
       bottom: 0;
       width: 10vw;
       background-color: black;
+      transition: right 200ms ease;
     }
+
+    {{#if this.settingsService.isMinimized}}
+      body {
+        width: 100%;
+      }
+
+      #vemos-container {
+        right: -10vw;
+      }
+    {{/if}}
 
     #vemos-frame {
       height: 100%;

--- a/vemos-extension/app/components/frame-styles.js
+++ b/vemos-extension/app/components/frame-styles.js
@@ -2,4 +2,5 @@ import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
 export default class FrameStylesComponent extends Component {
   @service parentDomService;
+  @service settingsService;
 }

--- a/vemos-extension/app/components/maximize-button.hbs
+++ b/vemos-extension/app/components/maximize-button.hbs
@@ -1,0 +1,46 @@
+<EmberWormhole @destinationElement={{this.parentDomService.container}}>
+  <style>
+    .vemos-maximize-button {
+      position: fixed;
+      top: 0px;
+      right: 0;
+      height: 34px;
+      transition: all 200ms ease;
+      border-top-left-radius: 5px;
+      border-bottom-left-radius: 5px;
+      cursor: pointer;
+    }
+
+    .vemos-maximize-button svg {
+      height: 10px;
+      padding: 12px 8px;
+      fill: #ccc;
+      transition: all 200ms ease;
+    }
+
+    .vemos-maximize-button:hover svg {
+      fill: white;
+    }
+
+    {{#if this.settingsService.isMinimized}}
+      .vemos-maximize-button {
+        background: #66339955;
+      }
+      .vemos-maximize-button:hover {
+        background: rebeccapurple;
+      }
+      .vemos-maximize-button svg {
+        fill: white;
+        transform: rotate(180deg);
+        transform-origin: center;
+      }
+    {{else}}
+      .vemos-maximize-button {
+        background: transparent;
+      }
+    {{/if}}
+  </style>
+  <div class="vemos-maximize-button" role="button" {{on "click" this.settingsService.toggleMinimized}}>
+    <Svg::Chevron />
+  </div>
+</EmberWormhole>

--- a/vemos-extension/app/components/maximize-button.js
+++ b/vemos-extension/app/components/maximize-button.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class MaximizeButtonComponent extends Component {
+  @service settingsService;
+  @service parentDomService;
+}

--- a/vemos-extension/app/components/start-page.hbs
+++ b/vemos-extension/app/components/start-page.hbs
@@ -3,6 +3,7 @@
     <div class="sidebar__logo">
       <Svg::Logo/>
     </div>
+    <MaximizeButton />
   </div>
   <div class="layout__box {{if this.peerService.connections.length 'o__flexes-to-1'}} o__scrolls">
     <VideoList/>
@@ -36,3 +37,4 @@
     <Notice::Headphones @onClose={{this.disableHeadphoneWarning}}/>
   </ParentDomFrame>
 {{/if}}
+

--- a/vemos-extension/app/components/start-page.js
+++ b/vemos-extension/app/components/start-page.js
@@ -8,6 +8,7 @@ export default class StartPageComponent extends Component {
   @service peerService;
   @service videoSyncService;
   @service parentDomService;
+  @service settingsService;
 
   @tracked showHeadphoneWarning = true;
   @tracked linkText = "Copy invite link";

--- a/vemos-extension/app/components/svg/chevron.hbs
+++ b/vemos-extension/app/components/svg/chevron.hbs
@@ -1,0 +1,38 @@
+<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 256 256" style="enable-background:new 0 0 256 256;" xml:space="preserve">
+<g>
+	<g>
+		<polygon points="79.093,0 48.907,30.187 146.72,128 48.907,225.813 79.093,256 207.093,128 		"/>
+	</g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+</svg>

--- a/vemos-extension/app/services/settings-service.js
+++ b/vemos-extension/app/services/settings-service.js
@@ -1,0 +1,11 @@
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class SettingsServiceService extends Service {
+  @tracked isMinimized = false;
+
+  @action toggleMinimized() {
+    this.isMinimized = !this.isMinimized;
+  }
+}

--- a/vemos-extension/tests/integration/components/maximize-button-test.js
+++ b/vemos-extension/tests/integration/components/maximize-button-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | maximize-button', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<MaximizeButton />`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      <MaximizeButton>
+        template block text
+      </MaximizeButton>
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});

--- a/vemos-extension/tests/integration/components/svg/chevron-test.js
+++ b/vemos-extension/tests/integration/components/svg/chevron-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | svg/chevron', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<Svg::Chevron />`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      <Svg::Chevron>
+        template block text
+      </Svg::Chevron>
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});

--- a/vemos-extension/tests/unit/services/settings-service-test.js
+++ b/vemos-extension/tests/unit/services/settings-service-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | settings-service', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let service = this.owner.lookup('service:settings-service');
+    assert.ok(service);
+  });
+});


### PR DESCRIPTION
![toggling size](https://user-images.githubusercontent.com/2514088/79071207-4e7cce80-7cd2-11ea-905b-2b0cb8f8ebdf.gif)

for https://github.com/nolaneo/vemos/issues/7

Changes:
* Adds a `settingsService`.
* This service is for general settings that we might have in Vemos, including the state of the sidebar.
* Adds a toggle to open and collapse the sidebar.