### PR TITLE
Update permissions for Prime

### DIFF
--- a/vemos-extension/extension/background.js
+++ b/vemos-extension/extension/background.js
@@ -1,28 +1,24 @@
 let browser = window.browser || window.chrome;
 
+
+const KNOWN_HOSTS = [
+  "netflix.com",
+  "youtube.com",
+  "disneyplus.com",
+  "hulu.com",
+  "primevideo.com",
+  "primevideo.co.uk",
+  "amazon.com",
+  "amazon.co.uk",
+];
+
 browser.runtime.onInstalled.addListener(function () {
   browser.declarativeContent.onPageChanged.removeRules(undefined, function () {
     browser.declarativeContent.onPageChanged.addRules([
       {
-        conditions: [
-          new browser.declarativeContent.PageStateMatcher({
-            pageUrl: { hostSuffix: "netflix.com" },
-          }),
-          new browser.declarativeContent.PageStateMatcher({
-            pageUrl: { hostSuffix: "youtube.com" },
-          }),
-          new browser.declarativeContent.PageStateMatcher({
-            pageUrl: { hostSuffix: "hulu.com" },
-          }),
-          new browser.declarativeContent.PageStateMatcher({
-            pageUrl: { hostSuffix: "disneyplus.com" },
-          }),
-          new browser.declarativeContent.PageStateMatcher({
-            pageUrl: { hostSuffix: "primevideo.com" },
-          }),
-        ],
+        conditions: KNOWN_HOSTS.map(hostSuffix => new browser.declarativeContent.PageStateMatcher({ pageUrl: { hostSuffix } })),
         actions: [new browser.declarativeContent.ShowPageAction()],
-      },
+      }
     ]);
   });
 });

--- a/vemos-extension/extension/manifest.json
+++ b/vemos-extension/extension/manifest.json
@@ -24,7 +24,10 @@
         "*://*.netflix.com/*",
         "*://*.hulu.com/",
         "*://*.disneyplus.com/*",
-        "*://*.primevideo.com/*"
+        "*://*.primevideo.com/*",
+        "*://*.primevideo.co.uk/*",
+        "*://*.amazon.com/*",
+        "*://*.amazon.co.uk/*"
       ],
       "js": ["url.js"],
       "run_at": "document_start"
@@ -36,7 +39,10 @@
         "*://*.netflix.com/*",
         "*://*.hulu.com/",
         "*://*.disneyplus.com/*",
-        "*://*.primevideo.com/*"
+        "*://*.primevideo.com/*",
+        "*://*.primevideo.co.uk/*",
+        "*://*.amazon.com/*",
+        "*://*.amazon.co.uk/*"
       ],
       "js": ["assets/app.js", "content.js"],
       "css": ["assets/app.css"],


### PR DESCRIPTION
In the US and the UK, it seems primevideo is hosted from amazon.com and amazon.co.uk respectively.

This should help with unblocking those users from using Vemos on Prime https://github.com/nolaneo/vemos/issues/10

Right now I can't figure out how to make it optional to opt into certain websites while having a default list.