### PR TITLE
Encode URI and check extension presence via vemos.org

### DIFF
--- a/vemos-extension/app/components/start-page.js
+++ b/vemos-extension/app/components/start-page.js
@@ -41,7 +41,7 @@ export default class StartPageComponent extends Component {
   async generateLink() {
     let url = new URL(this.parentDomService.window.location.href);
     url.searchParams.append("vemos-id", this.peerService.peerId);
-    navigator.clipboard.writeText(url.toString());
+    navigator.clipboard.writeText("https://vemos.org/connect?destination=" + encodeURIComponent(url.toString()));
     this.linkText = "Copied!";
     await timeout(2000);
     this.linkText = "Copy invite link";

--- a/vemos-extension/extension/manifest.json
+++ b/vemos-extension/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Vemos",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Virtual movie nights made easy",
   "manifest_version": 2,
   "background": {

--- a/vemos-extension/extension/url.js
+++ b/vemos-extension/extension/url.js
@@ -2,9 +2,10 @@ let queryParamString = window.location.search;
 let queryParams = new URLSearchParams(queryParamString);
 
 if (window.location.host === 'vemos.org') {
+  console.log('Setting Vemos version');
   let browser = window.browser || window.chrome;
   let version = browser.runtime.getManifest().version;
-  window.VEMOS_VERSION = version;
+  window.document.documentElement.setAttribute('vemos-version', version);
 } else if (queryParams.get("vemos-id")) {
   window.VEMOS_PEER_ID = queryParams.get("vemos-id");
   let url = new URL(window.location.href);

--- a/vemos-extension/extension/url.js
+++ b/vemos-extension/extension/url.js
@@ -1,7 +1,11 @@
 let queryParamString = window.location.search;
 let queryParams = new URLSearchParams(queryParamString);
 
-if (queryParams.get("vemos-id")) {
+if (window.location.host === 'vemos.org') {
+  let browser = window.browser || window.chrome;
+  let version = browser.runtime.getManifest().version;
+  window.VEMOS_VERSION = version;
+} else if (queryParams.get("vemos-id")) {
   window.VEMOS_PEER_ID = queryParams.get("vemos-id");
   let url = new URL(window.location.href);
   url.searchParams.delete("vemos-id");
@@ -13,3 +17,4 @@ if (queryParams.get("vemos-id")) {
 } else {
   console.log("No peer id");
 }
+


### PR DESCRIPTION
All details here https://github.com/nolaneo/vemos/pull/17

Changes:
* Encode URI and append it as a param on a vemos.org url.
* Vemos.org will check if the user accessing the link actually has the extension, routing them to the chrome store if not.