### PR TITLE
Rework permissions

### DIFF
--- a/vemos-extension/app/components/start-page.js
+++ b/vemos-extension/app/components/start-page.js
@@ -21,10 +21,11 @@ export default class StartPageComponent extends Component {
 
   async attemptImmediateConnection() {
     await timeout(2000);
-    if (this.parentDomService.window.VEMOS_PEER_ID) {
+    let sepecifiedPeer = document.querySelector('#vemos-peer-id').getAttribute('content');
+    if (sepecifiedPeer) {
       console.log("Connecting to peer specified in query param");
       this.peerService.connectToPeer(
-        this.parentDomService.window.VEMOS_PEER_ID
+        sepecifiedPeer
       );
     }
   }

--- a/vemos-extension/config/environment.js
+++ b/vemos-extension/config/environment.js
@@ -18,7 +18,7 @@ module.exports = function (environment) {
     },
 
     APP: {
-      autoboot: false,
+      autoboot: true,
     },
   };
 

--- a/vemos-extension/config/environment.js
+++ b/vemos-extension/config/environment.js
@@ -51,10 +51,12 @@ module.exports = function (environment) {
     development: [
       ["/assets/app.js", "extension/assets/app.js"],
       ["/assets/app.css", "extension/assets/app.css"],
+      ["/assets/content-scripts-register-polyfill.js", "extension/content-scripts-register-polyfill.js"],
     ],
     production: [
       ["/assets/app.js", "extension/assets/app.js"],
       ["/assets/app.css", "extension/assets/app.css"],
+      ["/assets/content-scripts-register-polyfill.js", "extension/content-scripts-register-polyfill.js"],
     ],
   };
 

--- a/vemos-extension/ember-cli-build.js
+++ b/vemos-extension/ember-cli-build.js
@@ -18,5 +18,7 @@ module.exports = function (defaults) {
     },
   });
 
+  app.import('node_modules/content-scripts-register-polyfill/index.js', { outputFile: 'assets/content-scripts-register-polyfill.js' });
+
   return app.toTree();
 };

--- a/vemos-extension/extension/background.js
+++ b/vemos-extension/extension/background.js
@@ -13,37 +13,16 @@ browser.contentScripts.register({
   matches: ["http://*/", "https://*/"],
 });
 
-browser.runtime.onMessage.addListener(async (request, _, sendResponse) => {
-  if (request.registerContentScriptsOnUrl) {
-    await browser.contentScripts.register({
-      js: [{ file: 'url.js' }],
-      runAt: 'document_start',
-      matches: [request.registerContentScriptsOnUrl]
-    });
-    await browser.contentScripts.register({
-      js: [{ file: 'assets/app.js' }, { file: 'content.js' }],
-      css: [{ file: 'assets/app.css' }],
-      runAt: 'document_end',
-      matches: [request.registerContentScriptsOnUrl]
-    });
-    console.log("Content scripts registered", request.registerContentScriptsOnUrl);
-    sendResponse(true);
-  }
-});
-
 function contentScriptLoader() {
   browser.declarativeContent.onPageChanged.removeRules(undefined, function () {
-    browser.permissions.getAll(result => {
-      console.log(result.origins)      // [ "*://*.mozilla.org/*" ]
-      browser.declarativeContent.onPageChanged.addRules([
-        {
-          conditions: [new browser.declarativeContent.PageStateMatcher({ pageUrl: { schemes: ['http', 'https'] } })],
-          actions: [new browser.declarativeContent.RequestContentScript({
-            js: ['url.js', 'content.js']
-          })],
-        }
-      ]);
-    });
+    browser.declarativeContent.onPageChanged.addRules([
+      {
+        conditions: [new browser.declarativeContent.PageStateMatcher({ pageUrl: { schemes: ['http', 'https'] } })],
+        actions: [new browser.declarativeContent.RequestContentScript({
+          js: ['url.js', 'content.js']
+        })],
+      }
+    ]);
   });
 }
 

--- a/vemos-extension/extension/background.js
+++ b/vemos-extension/extension/background.js
@@ -39,7 +39,7 @@ function contentScriptLoader() {
         {
           conditions: [new browser.declarativeContent.PageStateMatcher({ pageUrl: { schemes: ['http', 'https'] } })],
           actions: [new browser.declarativeContent.RequestContentScript({
-            js: ['url.js', 'assets/app.js', 'content.js']
+            js: ['url.js', 'content.js']
           })],
         }
       ]);

--- a/vemos-extension/extension/background.js
+++ b/vemos-extension/extension/background.js
@@ -34,4 +34,24 @@ browser.runtime.onInstalled.addListener(function () {
 browser.permissions.onAdded.addListener(function() {
   console.log('On Added');
   contentScriptLoader();
-})
+});
+
+browser.runtime.onMessage.addListener(function(request, _, sendResponse) {
+  if (request.permissionURL) {
+    if (request.request) {
+      browser.permissions.request({
+        origins: [request.permissionURL]
+      }, result => {
+        sendResponse({ result: Boolean(result) });
+      });
+    } else {
+      browser.permissions.contains({
+        origins: [request.permissionURL]
+      }, result => {
+        sendResponse({ result: Boolean(result) });
+      });
+    }
+
+  }
+  return true;
+});

--- a/vemos-extension/extension/background.js
+++ b/vemos-extension/extension/background.js
@@ -39,7 +39,7 @@ function contentScriptLoader() {
         {
           conditions: [new browser.declarativeContent.PageStateMatcher({ pageUrl: { schemes: ['http', 'https'] } })],
           actions: [new browser.declarativeContent.RequestContentScript({
-            js: ['url.js', 'content.js']
+            js: ['url.js', 'assets/app.js', 'content.js']
           })],
         }
       ]);

--- a/vemos-extension/extension/background.js
+++ b/vemos-extension/extension/background.js
@@ -1,24 +1,19 @@
 let browser = window.browser || window.chrome;
 
-
-const KNOWN_HOSTS = [
-  "netflix.com",
-  "youtube.com",
-  "disneyplus.com",
-  "hulu.com",
-  "primevideo.com",
-  "primevideo.co.uk",
-  "amazon.com",
-  "amazon.co.uk",
-];
-
-browser.runtime.onInstalled.addListener(function () {
-  browser.declarativeContent.onPageChanged.removeRules(undefined, function () {
-    browser.declarativeContent.onPageChanged.addRules([
-      {
-        conditions: KNOWN_HOSTS.map(hostSuffix => new browser.declarativeContent.PageStateMatcher({ pageUrl: { hostSuffix } })),
-        actions: [new browser.declarativeContent.ShowPageAction()],
-      }
-    ]);
-  });
+browser.runtime.onMessage.addListener(async (request, _, sendResponse) => {
+  if (request.registerContentScriptsOnUrl) {
+    await browser.contentScripts.register({
+      js: [{ file: 'url.js' }],
+      runAt: 'document_start',
+      matches: [request.registerContentScriptsOnUrl]
+    });
+    await browser.contentScripts.register({
+      js: [{ file: 'assets/app.js' }, { file: 'content.js' }],
+      css: [{ file: 'assets/app.css' }],
+      runAt: 'document_end',
+      matches: [request.registerContentScriptsOnUrl]
+    });
+    console.log("Content scripts registered", request.registerContentScriptsOnUrl);
+    sendResponse(true);
+  }
 });

--- a/vemos-extension/extension/background.js
+++ b/vemos-extension/extension/background.js
@@ -1,5 +1,18 @@
 let browser = window.browser || window.chrome;
 
+browser.contentScripts.register({
+  js: [{ file: 'url.js' }],
+  runAt: 'document_start',
+  matches: ["http://*/", "https://*/"],
+});
+
+browser.contentScripts.register({
+  js: [{ file: 'assets/app.js' }, { file: 'content.js' }],
+  css: [{ file: 'assets/app.css' }],
+  runAt: 'document_end',
+  matches: ["http://*/", "https://*/"],
+});
+
 browser.runtime.onMessage.addListener(async (request, _, sendResponse) => {
   if (request.registerContentScriptsOnUrl) {
     await browser.contentScripts.register({
@@ -17,3 +30,29 @@ browser.runtime.onMessage.addListener(async (request, _, sendResponse) => {
     sendResponse(true);
   }
 });
+
+function contentScriptLoader() {
+  browser.declarativeContent.onPageChanged.removeRules(undefined, function () {
+    browser.permissions.getAll(result => {
+      console.log(result.origins)      // [ "*://*.mozilla.org/*" ]
+      browser.declarativeContent.onPageChanged.addRules([
+        {
+          conditions: [new browser.declarativeContent.PageStateMatcher({ pageUrl: { schemes: ['http', 'https'] } })],
+          actions: [new browser.declarativeContent.RequestContentScript({
+            js: ['url.js', 'content.js']
+          })],
+        }
+      ]);
+    });
+  });
+}
+
+browser.runtime.onInstalled.addListener(function () {
+  console.log('On Install');
+  contentScriptLoader();
+});
+
+browser.permissions.onAdded.addListener(function() {
+  console.log('On Added');
+  contentScriptLoader();
+})

--- a/vemos-extension/extension/content-scripts-register-polyfill.js
+++ b/vemos-extension/extension/content-scripts-register-polyfill.js
@@ -1,0 +1,94 @@
+"use strict";
+function urlGlobToRegex(matchPattern) {
+    return '^' + matchPattern
+        .replace(/[.]/g, '\\.') // Escape dots
+        .replace(/[?]/, '.') // Single-character wildcards
+        .replace(/^[*]:/, 'https?') // Protocol
+        .replace(/^(https[?]?:[/][/])[*]/, '$1[^/:]+') // Subdomain wildcard
+        .replace(/[/][*]/, '/?.+') // Whole path wildcards (so it can match the whole origin)
+        .replace(/[*]/g, '.+') // Path wildcards
+        .replace(/[/]/g, '\\/'); // Escape slashes
+}
+// @ts-ignore
+async function p(fn, ...args) {
+    return new Promise((resolve, reject) => {
+        // @ts-ignore
+        fn(...args, result => {
+            if (chrome.runtime.lastError) {
+                reject(chrome.runtime.lastError);
+            }
+            else {
+                resolve(result);
+            }
+        });
+    });
+}
+async function isOriginPermitted(url) {
+    return p(chrome.permissions.contains, {
+        origins: [new URL(url).origin + '/*']
+    });
+}
+async function wasPreviouslyLoaded(tabId, loadCheck) {
+    const result = await p(chrome.tabs.executeScript, tabId, {
+        code: loadCheck,
+        runAt: 'document_start'
+    });
+    return result && result[0];
+}
+if (!chrome.contentScripts) {
+    chrome.contentScripts = {
+        // The callback is only used by webextension-polyfill
+        async register(contentScriptOptions, callback) {
+            const { js = [], css = [], allFrames, matchAboutBlank, matches, runAt } = contentScriptOptions;
+            // Injectable code; it sets a `true` property on `document` with the hash of the files as key.
+            const loadCheck = `document[${JSON.stringify(JSON.stringify({ js, css }))}]`;
+            const matchesRegex = new RegExp(matches.map(urlGlobToRegex).join('$') + '$');
+            const listener = async (tabId, { status }) => {
+                if (status !== 'loading') {
+                    return;
+                }
+                const { url } = await p(chrome.tabs.get, tabId);
+                if (!url || // No URL = no permission;
+                    !matchesRegex.test(url) || // Manual `matches` glob matching
+                    !await isOriginPermitted(url) || // Permissions check
+                    await wasPreviouslyLoaded(tabId, loadCheck) // Double-injection avoidance
+                ) {
+                    return;
+                }
+                for (const file of css) {
+                    chrome.tabs.insertCSS(tabId, {
+                        ...file,
+                        matchAboutBlank,
+                        allFrames,
+                        runAt: runAt || 'document_start' // CSS should prefer `document_start` when unspecified
+                    });
+                }
+                for (const file of js) {
+                    chrome.tabs.executeScript(tabId, {
+                        ...file,
+                        matchAboutBlank,
+                        allFrames,
+                        runAt
+                    });
+                }
+                // Mark as loaded
+                chrome.tabs.executeScript(tabId, {
+                    code: `${loadCheck} = true`,
+                    runAt: 'document_start',
+                    allFrames
+                });
+            };
+            chrome.tabs.onUpdated.addListener(listener);
+            const registeredContentScript = {
+                async unregister() {
+                    return p(chrome.tabs.onUpdated.removeListener.bind(chrome.tabs.onUpdated), listener);
+                }
+            };
+            if (typeof callback === 'function') {
+                callback(registeredContentScript);
+            }
+            return Promise.resolve(registeredContentScript);
+        }
+    };
+}
+//# sourceMappingURL=content-scripts-register-polyfill.map

--- a/vemos-extension/extension/content.js
+++ b/vemos-extension/extension/content.js
@@ -1,89 +1,102 @@
 /* global require */
 
-const EXTENSION_ID = "vemos-container";
-const IFRAME_ID = "vemos-frame";
+if (window.VEMOS_CONTENT_SET)  {
+  console.log('VEMOS CONTENT ALREADY INITIALIZED');
+} else {
+  const EXTENSION_ID = "vemos-container";
+  const IFRAME_ID = "vemos-frame";
 
-class ContentScript {
-  get browser() {
-    return window.browser || window.chrome;
-  }
+  class ContentScript {
+    get browser() {
+      return window.browser || window.chrome;
+    }
 
-  injectVemos() {
-    if (document.body && document.contentType !== "application/pdf") {
-      this.injectExtensionFrame();
-      this.injectEmberApp();
-      let iframe = document.getElementById(IFRAME_ID);
-      require("vemos-plugin/app")["default"].create({
-        rootElement: iframe.contentDocument.body,
-      });
-
-      let script = document.createElement("script");
-      script.type = "text/javascript";
-      script.id = "vemos-netflix-reference";
-      script.innerHTML = `
-        console.log('Vemos - Adding Netflix API Listener');
-        window.addEventListener("message", (event) => {
-          if (event.data.vemosSeekTime) {
-            console.log("VEMOS Neflix API seek", event.data.vemosSeekTime);
-            let videoPlayer = netflix.appContext.state.playerApp.getAPI().videoPlayer;
-            let player = videoPlayer.getVideoPlayerBySessionId(
-              videoPlayer.getAllPlayerSessionIds()[0]
-            );
-            player.seek(Math.round(Number(event.data.vemosSeekTime)) * 1000);
-          }
+    injectVemos() {
+      if (document.body && document.contentType !== "application/pdf") {
+        this.injectExtensionFrame();
+        this.injectEmberApp();
+        let iframe = document.getElementById(IFRAME_ID);
+        require("vemos-plugin/app")["default"].create({
+          rootElement: iframe.contentDocument.body,
         });
-      `;
-      document.head.appendChild(script);
+
+        let script = document.createElement("script");
+        script.type = "text/javascript";
+        script.id = "vemos-netflix-reference";
+        script.innerHTML = `
+          console.log('Vemos - Adding Netflix API Listener');
+          window.addEventListener("message", (event) => {
+            if (event.data.vemosSeekTime) {
+              console.log("VEMOS Neflix API seek", event.data.vemosSeekTime);
+              let videoPlayer = netflix.appContext.state.playerApp.getAPI().videoPlayer;
+              let player = videoPlayer.getVideoPlayerBySessionId(
+                videoPlayer.getAllPlayerSessionIds()[0]
+              );
+              player.seek(Math.round(Number(event.data.vemosSeekTime)) * 1000);
+            }
+          });
+        `;
+        document.head.appendChild(script);
+      }
+    }
+
+    injectExtensionFrame() {
+      let vemosExtension = document.createElement("div");
+      vemosExtension.id = EXTENSION_ID;
+      let iframe = document.createElement("iframe");
+      iframe.id = IFRAME_ID;
+      iframe.frameBorder = 0;
+      vemosExtension.appendChild(iframe);
+      document.body.insertAdjacentElement("afterEnd", vemosExtension);
+      iframe.contentDocument;
+    }
+
+    injectEmberApp() {
+      const iframe = window.document.getElementById(IFRAME_ID);
+      this.injectFrameTemplate(iframe);
+    }
+
+    injectFrameTemplate(iframe) {
+      iframe.contentDocument.open();
+      iframe.contentDocument.write(`
+        <html id="vemos-html">
+          <head>
+            <title>Vemos</title>
+            <link rel="stylesheet" type="text/css" href="${this.browser.runtime.getURL(
+              "assets/app.css"
+            )}" />
+          </head>
+          <body id="vemos-body"></body>
+        </html>
+      `);
+      iframe.contentDocument.close();
+      iframe.contentWindow.VEMOS_NETFLIX_PLAYER = window.VEMOS_NETFLIX_PLAYER;
     }
   }
 
-  injectExtensionFrame() {
-    let vemosExtension = document.createElement("div");
-    vemosExtension.id = EXTENSION_ID;
-    let iframe = document.createElement("iframe");
-    iframe.id = IFRAME_ID;
-    iframe.frameBorder = 0;
-    vemosExtension.appendChild(iframe);
-    document.body.insertAdjacentElement("afterEnd", vemosExtension);
-    iframe.contentDocument;
+  window.VEMOS_CONTENT_SET = true;
+
+  if (window.VEMOS_PEER_ID) {
+    setTimeout(async () => {
+      console.log("A Peer ID was present, booting Vemos");
+      await browser.tabs.executeScript({ file: 'assets/app.js' });
+      let contentScript = new ContentScript();
+      contentScript.injectVemos();
+    }, 1000);
   }
 
-  injectEmberApp() {
-    const iframe = window.document.getElementById(IFRAME_ID);
-    this.injectFrameTemplate(iframe);
-  }
+  let browser = window.browser || window.chrome;
 
-  injectFrameTemplate(iframe) {
-    iframe.contentDocument.open();
-    iframe.contentDocument.write(`
-      <html id="vemos-html">
-        <head>
-          <title>Vemos</title>
-          <link rel="stylesheet" type="text/css" href="${this.browser.runtime.getURL(
-            "assets/app.css"
-          )}" />
-        </head>
-        <body id="vemos-body"></body>
-      </html>
-    `);
-    iframe.contentDocument.close();
-    iframe.contentWindow.VEMOS_NETFLIX_PLAYER = window.VEMOS_NETFLIX_PLAYER;
+  if (browser.runtime) {
+    console.log("Adding Vemos message listener");
+    browser.runtime.onMessage.addListener(async function (request, _, sendResponse) {
+      if (request.startVemos) {
+        await browser.tabs.executeScript({ file: 'assets/app.js' });
+        console.log("Message received. Starting Vemos!");
+        let contentScript = new ContentScript();
+        contentScript.injectVemos();
+        sendResponse(true);
+      }
+    });  
   }
 }
-
-if (window.VEMOS_PEER_ID) {
-  let contentScript = new ContentScript();
-  contentScript.injectVemos();
-}
-
-let browser = window.browser || window.chrome;
-
-console.log("Adding Vemos message listener");
-browser.runtime.onMessage.addListener(function (request, _, sendResponse) {
-  if (request.startVemos) {
-    console.log("Message received. Starting Vemos!");
-    let contentScript = new ContentScript();
-    contentScript.injectVemos();
-    sendResponse(true);
-  }
-});

--- a/vemos-extension/extension/content.js
+++ b/vemos-extension/extension/content.js
@@ -101,7 +101,7 @@ if (window.VEMOS_CONTENT_SET)  {
       console.log("A Peer ID was present, booting Vemos");
       let contentScript = new ContentScript();
       contentScript.injectVemos();
-    }, 100);
+    }, 250);
   }
 
   let browser = window.browser || window.chrome;

--- a/vemos-extension/extension/content.js
+++ b/vemos-extension/extension/content.js
@@ -15,10 +15,6 @@ if (window.VEMOS_CONTENT_SET)  {
       if (document.body && document.contentType !== "application/pdf") {
         this.injectExtensionFrame();
         this.injectEmberApp();
-        // let iframe = document.getElementById(IFRAME_ID);
-        // require("vemos-plugin/app")["default"].create({
-        //   rootElement: iframe.contentDocument.body,
-        // });
 
         let script = document.createElement("script");
         script.type = "text/javascript";

--- a/vemos-extension/extension/content.js
+++ b/vemos-extension/extension/content.js
@@ -78,6 +78,7 @@ if (window.VEMOS_PEER_ID) {
 
 let browser = window.browser || window.chrome;
 
+console.log("Adding Vemos message listener");
 browser.runtime.onMessage.addListener(function (request, _, sendResponse) {
   if (request.startVemos) {
     console.log("Message received. Starting Vemos!");

--- a/vemos-extension/extension/content.js
+++ b/vemos-extension/extension/content.js
@@ -15,10 +15,10 @@ if (window.VEMOS_CONTENT_SET)  {
       if (document.body && document.contentType !== "application/pdf") {
         this.injectExtensionFrame();
         this.injectEmberApp();
-        let iframe = document.getElementById(IFRAME_ID);
-        require("vemos-plugin/app")["default"].create({
-          rootElement: iframe.contentDocument.body,
-        });
+        // let iframe = document.getElementById(IFRAME_ID);
+        // require("vemos-plugin/app")["default"].create({
+        //   rootElement: iframe.contentDocument.body,
+        // });
 
         let script = document.createElement("script");
         script.type = "text/javascript";
@@ -62,14 +62,38 @@ if (window.VEMOS_CONTENT_SET)  {
         <html id="vemos-html">
           <head>
             <title>Vemos</title>
-            <link rel="stylesheet" type="text/css" href="${this.browser.runtime.getURL(
-              "assets/app.css"
-            )}" />
           </head>
           <body id="vemos-body"></body>
         </html>
       `);
+
+      
       iframe.contentDocument.close();
+
+      let script = document.createElement('script');
+      script.type = 'text/javascript';
+      script.charset = 'utf-8';
+      script.src = this.browser.runtime.getURL("assets/app.js");
+
+
+      let styles = document.createElement('link');
+      styles.type = 'text/css';
+      styles.rel = "stylesheet";
+      styles.charset = 'utf-8';
+      styles.href = this.browser.runtime.getURL("assets/app.css");
+
+      iframe.contentWindow.document.head.appendChild(script);
+      iframe.contentWindow.document.head.appendChild(styles);
+
+      if (window.VEMOS_PEER_ID) {
+        let meta = document.createElement('meta');
+        meta.id = 'vemos-peer-id';
+        meta.name ="VEMOS_PEER_ID";
+        meta.content = window.VEMOS_PEER_ID;
+        iframe.contentWindow.document.head.appendChild(meta);
+
+      }
+
       iframe.contentWindow.VEMOS_NETFLIX_PLAYER = window.VEMOS_NETFLIX_PLAYER;
     }
   }
@@ -77,12 +101,11 @@ if (window.VEMOS_CONTENT_SET)  {
   window.VEMOS_CONTENT_SET = true;
 
   if (window.VEMOS_PEER_ID) {
-    setTimeout(async () => {
+    setTimeout(() =>{
       console.log("A Peer ID was present, booting Vemos");
-      await browser.tabs.executeScript({ file: 'assets/app.js' });
       let contentScript = new ContentScript();
       contentScript.injectVemos();
-    }, 1000);
+    }, 100);
   }
 
   let browser = window.browser || window.chrome;
@@ -91,7 +114,6 @@ if (window.VEMOS_CONTENT_SET)  {
     console.log("Adding Vemos message listener");
     browser.runtime.onMessage.addListener(async function (request, _, sendResponse) {
       if (request.startVemos) {
-        await browser.tabs.executeScript({ file: 'assets/app.js' });
         console.log("Message received. Starting Vemos!");
         let contentScript = new ContentScript();
         contentScript.injectVemos();

--- a/vemos-extension/extension/manifest.json
+++ b/vemos-extension/extension/manifest.json
@@ -39,8 +39,11 @@
     "48": "icons/48.png",
     "128": "icons/128.png"
   },
-  "permissions": ["activeTab", "*://*.vemos.org/*"],
-  "optional_permissions": ["<all_urls>"],
+  "permissions": ["activeTab", "declarativeContent", "*://*.vemos.org/*"],
+  "optional_permissions": [
+    "http://*/*",
+    "https://*/*"
+  ],
   "web_accessible_resources": ["assets/app.css", "assets/app.js"],
   "content_security_policy": "script-src 'self'; object-src 'self'; font-src 'self'; connect-src 'self';"
 }

--- a/vemos-extension/extension/manifest.json
+++ b/vemos-extension/extension/manifest.json
@@ -4,10 +4,10 @@
   "description": "Virtual movie nights made easy",
   "manifest_version": 2,
   "background": {
-    "scripts": ["background.js"],
+    "scripts": ["content-scripts-register-polyfill.js", "background.js"],
     "persistent": false
   },
-  "page_action": {
+  "browser_action": {
     "default_popup": "popup.html",
     "default_icon": {
       "16": "icons/16.png",
@@ -19,30 +19,14 @@
   "content_scripts": [
     {
       "matches": [
-        "*://*.vemos.org/*",
-        "*://*.youtube.com/*",
-        "*://*.netflix.com/*",
-        "*://*.hulu.com/",
-        "*://*.disneyplus.com/*",
-        "*://*.primevideo.com/*",
-        "*://*.primevideo.co.uk/*",
-        "*://*.amazon.com/*",
-        "*://*.amazon.co.uk/*"
+        "*://*.vemos.org/*"
       ],
       "js": ["url.js"],
       "run_at": "document_start"
     },
     {
       "matches": [
-        "*://*.vemos.org/*",
-        "*://*.youtube.com/*",
-        "*://*.netflix.com/*",
-        "*://*.hulu.com/",
-        "*://*.disneyplus.com/*",
-        "*://*.primevideo.com/*",
-        "*://*.primevideo.co.uk/*",
-        "*://*.amazon.com/*",
-        "*://*.amazon.co.uk/*"
+        "*://*.vemos.org/*"
       ],
       "js": ["assets/app.js", "content.js"],
       "css": ["assets/app.css"],
@@ -55,7 +39,8 @@
     "48": "icons/48.png",
     "128": "icons/128.png"
   },
-  "permissions": ["activeTab", "declarativeContent", "*://*.vemos.org/*"],
+  "permissions": ["activeTab", "*://*.vemos.org/*"],
+  "optional_permissions": ["<all_urls>"],
   "web_accessible_resources": ["assets/app.css", "assets/app.js"],
   "content_security_policy": "script-src 'self'; object-src 'self'; font-src 'self'; connect-src 'self';"
 }

--- a/vemos-extension/extension/manifest.json
+++ b/vemos-extension/extension/manifest.json
@@ -18,6 +18,11 @@
   },
   "content_scripts": [
     {
+      "matches": ["*://*.vemos.org/connect", "http://localhost/*"],
+      "js": ["permission_check.js"],
+      "run_at": "document_start"
+    },
+    {
       "matches": [
         "*://*.vemos.org/*"
       ],
@@ -28,7 +33,7 @@
       "matches": [
         "*://*.vemos.org/*"
       ],
-      "js": ["assets/app.js", "content.js"],
+      "js": ["content.js"],
       "css": ["assets/app.css"],
       "run_at": "document_end"
     }
@@ -39,7 +44,7 @@
     "48": "icons/48.png",
     "128": "icons/128.png"
   },
-  "permissions": ["activeTab", "declarativeContent", "*://*.vemos.org/*"],
+  "permissions": ["activeTab", "declarativeContent", "*://*.vemos.org/*", "http://localhost/*"],
   "optional_permissions": [
     "http://*/*",
     "https://*/*"

--- a/vemos-extension/extension/manifest.json
+++ b/vemos-extension/extension/manifest.json
@@ -18,7 +18,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["*://*.vemos.org/connect", "http://localhost/*"],
+      "matches": ["*://*.vemos.org/connect"],
       "js": ["permission_check.js"],
       "run_at": "document_start"
     },
@@ -44,7 +44,7 @@
     "48": "icons/48.png",
     "128": "icons/128.png"
   },
-  "permissions": ["tabs", "declarativeContent", "*://*.vemos.org/*", "http://localhost/*"],
+  "permissions": ["tabs", "declarativeContent", "*://*.vemos.org/*"],
   "optional_permissions": [
     "http://*/*",
     "https://*/*"

--- a/vemos-extension/extension/manifest.json
+++ b/vemos-extension/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Vemos",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Virtual movie nights made easy",
   "manifest_version": 2,
   "background": {
@@ -44,7 +44,7 @@
     "48": "icons/48.png",
     "128": "icons/128.png"
   },
-  "permissions": ["activeTab", "declarativeContent", "*://*.vemos.org/*", "http://localhost/*"],
+  "permissions": ["tabs", "declarativeContent", "*://*.vemos.org/*", "http://localhost/*"],
   "optional_permissions": [
     "http://*/*",
     "https://*/*"

--- a/vemos-extension/extension/permission_check.js
+++ b/vemos-extension/extension/permission_check.js
@@ -1,0 +1,17 @@
+window.addEventListener('DOMContentLoaded', () => {
+  console.log("Setting vemos-version");
+  let browser = window.browser || window.chrome;
+  window.document.documentElement.setAttribute('vemos-version', browser.runtime.getManifest().version);
+})
+
+window.addEventListener("message", event => {
+  let browser = window.browser || window.chrome;
+  let permissionURL = event.data.permissionURL;
+  let request = event.data.request;
+  if (permissionURL) {
+    browser.runtime.sendMessage({ permissionURL, request }, (response) => {
+      console.log('Permission available?', response.result);
+      window.postMessage({ permissionResult: response.result ? 'available' : 'unavailable' }, '*');
+    });
+  }
+});

--- a/vemos-extension/extension/popup.css
+++ b/vemos-extension/extension/popup.css
@@ -34,6 +34,12 @@
   background-color: white;
 }
 
+#permission-description {
+  color: #ccc;
+  text-align: center;
+  padding: 10px;
+}
+
 .layout__box {
   flex: 0 0 auto;
   min-width: 0;

--- a/vemos-extension/extension/popup.html
+++ b/vemos-extension/extension/popup.html
@@ -33,5 +33,9 @@
     <div id="get-permissions" class="popup-button" role="button">
       
     </div>
+    <div id="permission-description">
+      After granting permissions to Vemos, you can open this popup again and start the app.
+    </div>
+
   </body>
 </html>

--- a/vemos-extension/extension/popup.html
+++ b/vemos-extension/extension/popup.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <link href="popup.css" rel="stylesheet" type="text/css" />
+    <script type="text/javascript" src="content-scripts-register-polyfill.js"></script>
     <script type="text/javascript" src="popup.js"></script>
   </head>
   <body class="popup layout__box">
@@ -27,6 +28,10 @@
     </div>
     <div id="start-vemos" class="popup-button" role="button">
       Start watching together!
+    </div>
+
+    <div id="get-permissions" class="popup-button" role="button">
+      
     </div>
   </body>
 </html>

--- a/vemos-extension/extension/popup.js
+++ b/vemos-extension/extension/popup.js
@@ -13,7 +13,7 @@ async function openVemos(tabs) {
       console.log("Vemos Started Result:", response);
       window.close();
     });
-  }, 200);
+  }, 250);
 }
 
   

--- a/vemos-extension/extension/popup.js
+++ b/vemos-extension/extension/popup.js
@@ -63,7 +63,6 @@ window.addEventListener("DOMContentLoaded", () => {
       origins: [permissionURL]
     }, (hasPermission) => {
       if (hasPermission) {
-        executeScripts();
         getPermissions.style.display = 'none';
       } else {
         getPermissions.innerText = `Allow Vemos to run on ${url.host}`;

--- a/vemos-extension/extension/popup.js
+++ b/vemos-extension/extension/popup.js
@@ -2,16 +2,18 @@ let browser = window.browser || window.chrome;
 
 async function executeScripts() {
   await browser.tabs.executeScript({ file: 'url.js' });
-  await browser.tabs.executeScript({ file: 'assets/app.js' });
   await browser.tabs.executeScript({ file: 'content.js' });
 }
 
 async function openVemos(tabs) {
   console.log('Open Vemos');
-  browser.tabs.sendMessage(tabs[0].id, { startVemos: true }, (response) => {
-    console.log("Vemos Started Result:", response);
-    window.close();
-  });
+  await executeScripts();
+  setTimeout(() => {
+    browser.tabs.sendMessage(tabs[0].id, { startVemos: true }, (response) => {
+      console.log("Vemos Started Result:", response);
+      window.close();
+    });
+  }, 200);
 }
 
   
@@ -45,7 +47,6 @@ function requestPermissions(permissionURL) {
         startVemos.style.display = 'block';
         getPermissions.style.display = 'none';
         getPermissionsDescription.style.display = 'none';
-        executeScripts();
       } else {
         console.log('Permission refused');
       }
@@ -79,6 +80,7 @@ window.addEventListener("DOMContentLoaded", () => {
 
   startVemos.onclick = () => {
     browser.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      executeScripts();
       openVemos(tabs);
     });
   };

--- a/vemos-extension/extension/popup.js
+++ b/vemos-extension/extension/popup.js
@@ -1,17 +1,13 @@
 let browser = window.browser || window.chrome;
 
 async function executeScripts() {
-  if (!window.EXECUTED_SCRIPTS) {
-    await browser.tabs.executeScript({ file: 'url.js' });
-    await browser.tabs.executeScript({ file: 'assets/app.js' });
-    await browser.tabs.executeScript({ file: 'content.js' });
-    window.EXECUTED_SCRIPTS = true;
-  }
+  await browser.tabs.executeScript({ file: 'url.js' });
+  await browser.tabs.executeScript({ file: 'assets/app.js' });
+  await browser.tabs.executeScript({ file: 'content.js' });
 }
 
 async function openVemos(tabs) {
   console.log('Open Vemos');
-  executeScripts();
   browser.tabs.sendMessage(tabs[0].id, { startVemos: true }, (response) => {
     console.log("Vemos Started Result:", response);
     window.close();
@@ -61,7 +57,7 @@ window.addEventListener("DOMContentLoaded", () => {
   browser.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     console.log('URL',tabs[0].url);
     let url = new URL(tabs[0].url);
-    let permissionURL = `*://${url.host}/*`;
+    let permissionURL = `${url.protocol}//${url.host}/*`;
 
     browser.permissions.contains({
       origins: [permissionURL]
@@ -87,7 +83,7 @@ window.addEventListener("DOMContentLoaded", () => {
     browser.tabs.query({ active: true, currentWindow: true }, async (tabs) => {
       console.log('URL',tabs[0].url);
       let url = new URL(tabs[0].url);
-      let permissionURL = `*://${url.host}/*`;
+      let permissionURL = `${url.protocol}//${url.host}/*`;
       await requestPermissions(permissionURL);
     });
   };

--- a/vemos-extension/extension/popup.js
+++ b/vemos-extension/extension/popup.js
@@ -1,14 +1,94 @@
 let browser = window.browser || window.chrome;
 
+async function executeScripts() {
+  if (!window.EXECUTED_SCRIPTS) {
+    await browser.tabs.executeScript({ file: 'url.js' });
+    await browser.tabs.executeScript({ file: 'assets/app.js' });
+    await browser.tabs.executeScript({ file: 'content.js' });
+    window.EXECUTED_SCRIPTS = true;
+  }
+}
+
+async function openVemos(tabs) {
+  console.log('Open Vemos');
+  executeScripts();
+  browser.tabs.sendMessage(tabs[0].id, { startVemos: true }, (response) => {
+    console.log("Vemos Started Result:", response);
+    window.close();
+  });
+}
+
+  
+async function registerScripts(permissionURL) {
+  console.log('Register Vemos scripts');
+  await browser.contentScripts.register({
+    js: [{ file: 'url.js' }],
+    runAt: 'document_start',
+    matches: [permissionURL]
+  });
+  await browser.contentScripts.register({
+    js: [{ file: 'assets/app.js' }, { file: 'content.js' }],
+    css: [{ file: 'assets/app.css' }],
+    runAt: 'document_end',
+    matches: [permissionURL]
+  });
+
+}
+
+function requestPermissions(permissionURL) {
+  browser.permissions.request({
+    origins: [permissionURL]
+  }, async (granted) => {
+      if (granted) {
+        console.log('Permission given');
+        await registerScripts(permissionURL);
+        console.log("Content scripts registered", permissionURL);
+        let startVemos = document.getElementById("start-vemos");
+        let getPermissions = document.getElementById("get-permissions");
+        startVemos.style.display = 'block';
+        getPermissions.style.display = 'none';
+        executeScripts();
+      } else {
+        console.log('Permission refused');
+      }
+  });
+}
+
 window.addEventListener("DOMContentLoaded", () => {
   let startVemos = document.getElementById("start-vemos");
+  let getPermissions = document.getElementById("get-permissions");
+
+  browser.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    console.log('URL',tabs[0].url);
+    let url = new URL(tabs[0].url);
+    let permissionURL = `*://${url.host}/*`;
+
+    browser.permissions.contains({
+      origins: [permissionURL]
+    }, (hasPermission) => {
+      if (hasPermission) {
+        executeScripts();
+        getPermissions.style.display = 'none';
+      } else {
+        getPermissions.innerText = `Allow Vemos to run on ${url.host}`;
+        startVemos.style.display = 'none';
+      }
+    });
+  });
+
 
   startVemos.onclick = () => {
     browser.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      browser.tabs.sendMessage(tabs[0].id, { startVemos: true }, (response) => {
-        console.log("Vemos Started Result:", response);
-        window.close();
-      });
+      openVemos(tabs);
+    });
+  };
+
+  getPermissions.onclick = async () => {
+    browser.tabs.query({ active: true, currentWindow: true }, async (tabs) => {
+      console.log('URL',tabs[0].url);
+      let url = new URL(tabs[0].url);
+      let permissionURL = `*://${url.host}/*`;
+      await requestPermissions(permissionURL);
     });
   };
 });

--- a/vemos-extension/extension/popup.js
+++ b/vemos-extension/extension/popup.js
@@ -41,8 +41,10 @@ function requestPermissions(permissionURL) {
         console.log("Content scripts registered", permissionURL);
         let startVemos = document.getElementById("start-vemos");
         let getPermissions = document.getElementById("get-permissions");
+        let getPermissionsDescription = document.getElementById("permission-description");
         startVemos.style.display = 'block';
         getPermissions.style.display = 'none';
+        getPermissionsDescription.style.display = 'none';
         executeScripts();
       } else {
         console.log('Permission refused');
@@ -53,6 +55,8 @@ function requestPermissions(permissionURL) {
 window.addEventListener("DOMContentLoaded", () => {
   let startVemos = document.getElementById("start-vemos");
   let getPermissions = document.getElementById("get-permissions");
+  let getPermissionsDescription = document.getElementById("permission-description");
+
 
   browser.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     console.log('URL',tabs[0].url);
@@ -64,6 +68,7 @@ window.addEventListener("DOMContentLoaded", () => {
     }, (hasPermission) => {
       if (hasPermission) {
         getPermissions.style.display = 'none';
+        getPermissionsDescription.style.display = 'none';
       } else {
         getPermissions.innerText = `Allow Vemos to run on ${url.host}`;
         startVemos.style.display = 'none';

--- a/vemos-extension/extension/url.js
+++ b/vemos-extension/extension/url.js
@@ -1,21 +1,26 @@
-let queryParamString = window.location.search;
-let queryParams = new URLSearchParams(queryParamString);
-
-if (window.location.host === 'vemos.org') {
-  console.log('Setting Vemos version');
-  let browser = window.browser || window.chrome;
-  let version = browser.runtime.getManifest().version;
-  window.document.documentElement.setAttribute('vemos-version', version);
-} else if (queryParams.get("vemos-id")) {
-  window.VEMOS_PEER_ID = queryParams.get("vemos-id");
-  let url = new URL(window.location.href);
-  url.searchParams.delete("vemos-id");
-  window.history.replaceState(
-    window.history.state,
-    window.document.title,
-    url.toString()
-  );
+if (window.VEMOS_URL_SET)  {
+  console.log('VEMOS URL ALREADY INITIALIZED');
 } else {
-  console.log("No peer id");
+  let queryParamString = window.location.search;
+  let queryParams = new URLSearchParams(queryParamString);
+  
+  if (window.location.host === 'vemos.org') {
+    console.log('Setting Vemos version');
+    let browser = window.browser || window.chrome;
+    let version = browser.runtime.getManifest().version;
+    window.document.documentElement.setAttribute('vemos-version', version);
+  } else if (queryParams.get("vemos-id")) {
+    window.VEMOS_PEER_ID = queryParams.get("vemos-id");
+    let url = new URL(window.location.href);
+    url.searchParams.delete("vemos-id");
+    window.history.replaceState(
+      window.history.state,
+      window.document.title,
+      url.toString()
+    );
+  } else {
+    console.log("No peer id");
+  }
+  window.VEMOS_URL_SET = true;
 }
 

--- a/vemos-extension/extension/url.js
+++ b/vemos-extension/extension/url.js
@@ -10,6 +10,7 @@ if (window.VEMOS_URL_SET)  {
     let version = browser.runtime.getManifest().version;
     window.document.documentElement.setAttribute('vemos-version', version);
   } else if (queryParams.get("vemos-id")) {
+    console.log("Setting vemos peer id");
     window.VEMOS_PEER_ID = queryParams.get("vemos-id");
     let url = new URL(window.location.href);
     url.searchParams.delete("vemos-id");

--- a/vemos-extension/extension/url.js
+++ b/vemos-extension/extension/url.js
@@ -4,12 +4,7 @@ if (window.VEMOS_URL_SET)  {
   let queryParamString = window.location.search;
   let queryParams = new URLSearchParams(queryParamString);
   
-  if (window.location.host === 'vemos.org') {
-    console.log('Setting Vemos version');
-    let browser = window.browser || window.chrome;
-    let version = browser.runtime.getManifest().version;
-    window.document.documentElement.setAttribute('vemos-version', version);
-  } else if (queryParams.get("vemos-id")) {
+  if (queryParams.get("vemos-id")) {
     console.log("Setting vemos peer id");
     window.VEMOS_PEER_ID = queryParams.get("vemos-id");
     let url = new URL(window.location.href);

--- a/vemos-extension/package.json
+++ b/vemos-extension/package.json
@@ -65,6 +65,7 @@
     "edition": "octane"
   },
   "dependencies": {
+    "content-scripts-register-polyfill": "^1.0.0",
     "peerjs": "^1.2.0",
     "uuid": "^7.0.2"
   }

--- a/vemos-extension/yarn.lock
+++ b/vemos-extension/yarn.lock
@@ -1245,6 +1245,11 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
+"@types/firefox-webext-browser@^67.0.2":
+  version "67.0.2"
+  resolved "https://registry.yarnpkg.com/@types/firefox-webext-browser/-/firefox-webext-browser-67.0.2.tgz#04625d3294fbca54bccf42dae43f636c5b6452a2"
+  integrity sha512-tXR5THtH5Fqwfmi4y/2dTxCTebqHsKCH2bif/VdE5CPcB/S5x5fu+N+wBuMENzN41agovHMU/LQbtWNV+Aux+w==
+
 "@types/fs-extra@^5.0.5":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-5.1.0.tgz#2a325ef97901504a3828718c390d34b8426a10a1"
@@ -4162,6 +4167,13 @@ content-disposition@0.5.3:
   integrity sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==
   dependencies:
     safe-buffer "5.1.2"
+
+content-scripts-register-polyfill@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/content-scripts-register-polyfill/-/content-scripts-register-polyfill-1.0.0.tgz#21bc2df475ea48aa83737d24675a6a44e4a006a7"
+  integrity sha512-DiHscMTyL5evEg6C8GSkkd5Kfkma726zxqIt+zv6L2W/gVqYOUZUw2F27BpAUp9nQZnIrky5Gx1eYA9Fw4+aeA==
+  dependencies:
+    "@types/firefox-webext-browser" "^67.0.2"
 
 content-type@~1.0.4:
   version "1.0.4"

--- a/vemos-org/connect.html
+++ b/vemos-org/connect.html
@@ -24,6 +24,7 @@
 
     <script>
       window.addEventListener('DOMContentLoaded', (event) => {
+        console.log('Loading Vemos Version');
         let extensionVersion = window.document.documentElement.getAttribute('vemos-version');
         if (extensionVersion) {
           let queryParamString = window.location.search;
@@ -32,11 +33,31 @@
             console.log('Destination found');
             try {
               let destinationUrl = decodeURIComponent(queryParams.get("destination"));
-              gtag('event', 'action', {
-                'event_label': 'rerouting-successfully',
-                'non_interaction': true,
+
+              let url = new URL(destinationUrl);
+              let permissionURL = `${url.protocol}//${url.host}/*`;
+
+              window.addEventListener("message", event => {
+                if (event.data.permissionResult) {
+                  if (event.data.permissionResult == 'available') {
+                    gtag('event', 'action', {
+                      'event_label': 'rerouting-successfully',
+                      'non_interaction': true,
+                    });
+                    window.location.href = destinationUrl;
+                  } else {
+                    document.querySelector('.permission-section').classList.add('o__visible');
+                    document.querySelector('#site-name').innerHTML = url.host;
+                    document.querySelector('#grant-permissions').addEventListener("click", () => {
+                      window.postMessage({ permissionURL, request: true }, '*');
+
+                    })
+                  }
+                }
               });
-              window.location.href = destinationUrl;
+
+              window.postMessage({ permissionURL, request: false }, '*');
+
             } catch (error) {
               gtag('event', 'action', {
                 'event_label': 'parsing-error',
@@ -80,6 +101,12 @@
         <div class="not-installed">
           It looks like you don't have Vemos installed. Before joining your friends, you'll need to install it from the Chrome store. <a href="https://chrome.google.com/webstore/detail/pbonnafeomejlkdmjlealabfanohjogh">You can get it here.</a>
           Once installed, try the link again.
+        </div>
+        <div class="permission-section">
+          Pardon the interruption. Before we jump over to <b id="site-name"></b> Vemos needs permissions to run on that site first.
+          <button id="grant-permissions">
+            Grant permissions
+          </button>
         </div>
       </div>
     </div>

--- a/vemos-org/connect.html
+++ b/vemos-org/connect.html
@@ -103,10 +103,10 @@
           Once installed, try the link again.
         </div>
         <div class="permission-section">
-          Pardon the interruption. Before we jump over to <b id="site-name"></b> Vemos needs permissions to run on that site first.
-          <button id="grant-permissions">
+          Pardon the interruption.<br>Before we jump over to <b id="site-name"></b> Vemos needs permissions to run on that site first.
+          <div id="grant-permissions" role="button">
             Grant permissions
-          </button>
+          </div>
         </div>
       </div>
     </div>

--- a/vemos-org/connect.html
+++ b/vemos-org/connect.html
@@ -47,6 +47,7 @@
                     window.location.href = destinationUrl;
                   } else {
                     document.querySelector('.permission-section').classList.add('o__visible');
+                    document.querySelector('.loading-text').classList.add('o__hidden');
                     document.querySelector('#site-name').innerHTML = url.host;
                     document.querySelector('#grant-permissions').addEventListener("click", () => {
                       window.postMessage({ permissionURL, request: true }, '*');
@@ -96,19 +97,32 @@
         <img src="assets/images/logo-purple.svg">
         <div class="loading-text">Loading...</div>
         <div class="error-section">
+          <div class="section-title">Oh no!</div>
           Hmm, something went wrong. We couldn't figure out where to go from the link you received. Please check that you copied the whole link and try again.
         </div>
         <div class="not-installed">
+          <div class="section-title">Whoops, one second!</div>
+
           It looks like you don't have Vemos installed. Before joining your friends, you'll need to install it from the Chrome store. <a href="https://chrome.google.com/webstore/detail/pbonnafeomejlkdmjlealabfanohjogh">You can get it here.</a>
           Once installed, try the link again.
         </div>
         <div class="permission-section">
-          Pardon the interruption.<br>Before we jump over to <b id="site-name"></b> Vemos needs permissions to run on that site first.
+          <div class="section-title">Pardon the interruption.</div>
+          Before we jump over to <b id="site-name"></b> Vemos needs permissions to run on that site first. Click the button bellow to grant permissions.
           <div id="grant-permissions" role="button">
             Grant permissions
           </div>
         </div>
       </div>
     </div>
+    <script>
+      window.intercomSettings = {
+        app_id: "3dccd12b8cfcf5daf1f4546e6165e47fa95e3472"
+      };
+    </script>
+    
+    <script>
+    (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/3dccd12b8cfcf5daf1f4546e6165e47fa95e3472';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);};if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();
+    </script>
   </body>
 </html>

--- a/vemos-org/vemos.css
+++ b/vemos-org/vemos.css
@@ -48,7 +48,6 @@ body * {
   font-family: sans-serif;
 }
 
-.permission-section,
 .not-installed {
   padding: 10px;
   margin-top: 30px;
@@ -59,6 +58,26 @@ body * {
   display: none;
   font-family: sans-serif;
   line-height: 1.5;
+}
+
+.permission-section {
+  padding: 10px;
+  margin-top: 30px;
+  background-color: #fafafa;
+  border-radius: 3px;
+  border: 1px solid #aaa;
+  color: #555;
+  display: none;
+  font-family: sans-serif;
+  line-height: 1.5;
+}
+
+.section-title {
+  font-family: 'Playfair Display', serif;
+  font-weight: 700;
+  text-align: center;
+  font-size: 30px;
+  margin-bottom: 20px;
 }
 
 .error-section.o__visible,
@@ -73,16 +92,17 @@ body * {
   font-size: 14px;
   text-align: center;
   border-radius: 3px;
-  border: 2px solid #8a6d3b;
+  border: 2px solid var(--darkpurple);
   box-sizing: border-box;
-  margin-top: 10px;
+  margin-top: 30px;
   cursor: pointer;
+  transition: all 100ms;
 }
 
 #grant-permissions:hover {
   color: white;
-  background-color: yellowgreen;
-  border-color: darkolivegreen;
+  background-color: var(--darkpurple);
+  border-color: 2px solid var(--white);
 }
 
 .desktop .full-window {

--- a/vemos-org/vemos.css
+++ b/vemos-org/vemos.css
@@ -58,12 +58,31 @@ body * {
   color: #8a6d3b;
   display: none;
   font-family: sans-serif;
+  line-height: 1.5;
 }
 
 .error-section.o__visible,
 .permission-section.o__visible,
 .not-installed.o__visible {
   display: block;
+}
+
+#grant-permissions {
+  width: 100%;
+  padding: 5px;
+  font-size: 14px;
+  text-align: center;
+  border-radius: 3px;
+  border: 2px solid #8a6d3b;
+  box-sizing: border-box;
+  margin-top: 10px;
+  cursor: pointer;
+}
+
+#grant-permissions:hover {
+  color: white;
+  background-color: yellowgreen;
+  border-color: darkolivegreen;
 }
 
 .desktop .full-window {

--- a/vemos-org/vemos.css
+++ b/vemos-org/vemos.css
@@ -48,10 +48,7 @@ body * {
   font-family: sans-serif;
 }
 
-.error-section.o__visible {
-  display: block;
-}
-
+.permission-section,
 .not-installed {
   padding: 10px;
   margin-top: 30px;
@@ -63,6 +60,8 @@ body * {
   font-family: sans-serif;
 }
 
+.error-section.o__visible,
+.permission-section.o__visible,
 .not-installed.o__visible {
   display: block;
 }


### PR DESCRIPTION
This is a complete rework of the permissions system for Vemos.
It changes the required permissions to `tab`, `declarativeContent`, and `vemos.org` only.
There are optional permissions for `http:` and `https:` meaning you could _choose_ to run Vemos wherever you like.

When attempting to use the extension on a site for the first time, you'll get a permission request
![permissions-granting](https://user-images.githubusercontent.com/2514088/79220109-52802c00-7e4b-11ea-9edd-2043ddee0b0e.gif)

When you send an invite link to someone (via vemos.org/connect) and they do not have permissions for the site that we're going to redirect to, we instead show a warning:
![permissions-connect](https://user-images.githubusercontent.com/2514088/79220333-b1de3c00-7e4b-11ea-9e2f-0bfc7021e2c6.gif)

This should hopefully address how hard it is to get it Vemos released on the Chrome store.