### PR TITLE
Use background script to hold reference to Vemos peer id

### DIFF
--- a/vemos-extension/app/components/start-page.js
+++ b/vemos-extension/app/components/start-page.js
@@ -21,12 +21,12 @@ export default class StartPageComponent extends Component {
 
   async attemptImmediateConnection() {
     await timeout(2000);
-    let sepecifiedPeer = document.querySelector('#vemos-peer-id').getAttribute('content');
+    let sepecifiedPeer = document
+      .querySelector("#vemos-peer-id")
+      ?.getAttribute("content");
     if (sepecifiedPeer) {
       console.log("Connecting to peer specified in query param");
-      this.peerService.connectToPeer(
-        sepecifiedPeer
-      );
+      this.peerService.connectToPeer(sepecifiedPeer);
     }
   }
 
@@ -42,7 +42,10 @@ export default class StartPageComponent extends Component {
   async generateLink() {
     let url = new URL(this.parentDomService.window.location.href);
     url.searchParams.append("vemos-id", this.peerService.peerId);
-    navigator.clipboard.writeText("https://vemos.org/connect?destination=" + encodeURIComponent(url.toString()));
+    navigator.clipboard.writeText(
+      "https://vemos.org/connect?destination=" +
+        encodeURIComponent(url.toString())
+    );
     this.linkText = "Copied!";
     await timeout(2000);
     this.linkText = "Copy invite link";

--- a/vemos-extension/app/services/peer-service.js
+++ b/vemos-extension/app/services/peer-service.js
@@ -107,7 +107,7 @@ export default class PeerService extends Service {
   }
 
   onPeerError(error) {
-    console.log("onPeerError", error);
+    console.log("onPeerError", error.type, error);
   }
 
   onPeerCall(call) {
@@ -117,8 +117,8 @@ export default class PeerService extends Service {
     }
     call.on("stream", this.onStream.bind(this, call));
     call.on("addtrack", () => {
-      console.log('ADD TRACK');
-    })
+      console.log("ADD TRACK");
+    });
   }
 
   onStream(call, mediaStream) {

--- a/vemos-extension/extension/background.js
+++ b/vemos-extension/extension/background.js
@@ -69,9 +69,15 @@ browser.runtime.onMessage.addListener(function (request, _, sendResponse) {
 
 browser.runtime.onMessage.addListener(function (request, _, sendResponse) {
   if (request.setPeerId) {
-    console.log("Backgound peer id set to ", request.setPeerId);
+    console.log(
+      "Backgound peer id set to ",
+      request.setPeerId,
+      " for host ",
+      request.host
+    );
     window.vemosPeer = {
       id: request.setPeerId,
+      host: request.host,
       timeSet: new Date().getTime(),
     };
     sendResponse(true);
@@ -81,7 +87,7 @@ browser.runtime.onMessage.addListener(function (request, _, sendResponse) {
 
 browser.runtime.onMessage.addListener(function (request, _, sendResponse) {
   if (request.getPeerId) {
-    if (window.vemosPeer) {
+    if (window.vemosPeer && window.vemosPeer.host === request.host) {
       console.log("Backgound peer id is currently ", window.VEMOS_PEER_ID);
       let timeSet = window.vemosPeer.timeSet || 0;
 

--- a/vemos-extension/extension/background.js
+++ b/vemos-extension/extension/background.js
@@ -1,15 +1,15 @@
 let browser = window.browser || window.chrome;
 
 browser.contentScripts.register({
-  js: [{ file: 'url.js' }],
-  runAt: 'document_start',
+  js: [{ file: "url.js" }],
+  runAt: "document_start",
   matches: ["http://*/", "https://*/"],
 });
 
 browser.contentScripts.register({
-  js: [{ file: 'assets/app.js' }, { file: 'content.js' }],
-  css: [{ file: 'assets/app.css' }],
-  runAt: 'document_end',
+  js: [{ file: "assets/app.js" }, { file: "content.js" }],
+  css: [{ file: "assets/app.css" }],
+  runAt: "document_end",
   matches: ["http://*/", "https://*/"],
 });
 
@@ -17,41 +17,84 @@ function contentScriptLoader() {
   browser.declarativeContent.onPageChanged.removeRules(undefined, function () {
     browser.declarativeContent.onPageChanged.addRules([
       {
-        conditions: [new browser.declarativeContent.PageStateMatcher({ pageUrl: { schemes: ['http', 'https'] } })],
-        actions: [new browser.declarativeContent.RequestContentScript({
-          js: ['url.js', 'content.js']
-        })],
-      }
+        conditions: [
+          new browser.declarativeContent.PageStateMatcher({
+            pageUrl: { schemes: ["http", "https"] },
+          }),
+        ],
+        actions: [
+          new browser.declarativeContent.RequestContentScript({
+            js: ["url.js", "content.js"],
+          }),
+        ],
+      },
     ]);
   });
 }
 
 browser.runtime.onInstalled.addListener(function () {
-  console.log('On Install');
+  console.log("On Install");
   contentScriptLoader();
 });
 
-browser.permissions.onAdded.addListener(function() {
-  console.log('On Added');
+browser.permissions.onAdded.addListener(function () {
+  console.log("On Added");
   contentScriptLoader();
 });
 
-browser.runtime.onMessage.addListener(function(request, _, sendResponse) {
+browser.runtime.onMessage.addListener(function (request, _, sendResponse) {
   if (request.permissionURL) {
     if (request.request) {
-      browser.permissions.request({
-        origins: [request.permissionURL]
-      }, result => {
-        sendResponse({ result: Boolean(result) });
-      });
+      browser.permissions.request(
+        {
+          origins: [request.permissionURL],
+        },
+        (result) => {
+          sendResponse({ result: Boolean(result) });
+        }
+      );
     } else {
-      browser.permissions.contains({
-        origins: [request.permissionURL]
-      }, result => {
-        sendResponse({ result: Boolean(result) });
-      });
+      browser.permissions.contains(
+        {
+          origins: [request.permissionURL],
+        },
+        (result) => {
+          sendResponse({ result: Boolean(result) });
+        }
+      );
     }
+  }
+  return true;
+});
 
+browser.runtime.onMessage.addListener(function (request, _, sendResponse) {
+  if (request.setPeerId) {
+    console.log("Backgound peer id set to ", request.setPeerId);
+    window.vemosPeer = {
+      id: request.setPeerId,
+      timeSet: new Date().getTime(),
+    };
+    sendResponse(true);
+  }
+  return true;
+});
+
+browser.runtime.onMessage.addListener(function (request, _, sendResponse) {
+  if (request.getPeerId) {
+    if (window.vemosPeer) {
+      console.log("Backgound peer id is currently ", window.VEMOS_PEER_ID);
+      let timeSet = window.vemosPeer.timeSet || 0;
+
+      let oneMinuteInMS = 60 * 1000;
+      if (Math.abs(new Date().getTime() - timeSet) > oneMinuteInMS) {
+        console.log("Vemos peer id has expired");
+        sendResponse(undefined);
+      } else {
+        sendResponse(window.vemosPeer.id);
+      }
+    } else {
+      sendResponse(undefined);
+    }
   }
   return true;
 });

--- a/vemos-extension/extension/content.js
+++ b/vemos-extension/extension/content.js
@@ -109,15 +109,18 @@ if (window.VEMOS_CONTENT_SET) {
   );
 
   if (versionNumber > 5) {
-    browser.runtime.sendMessage({ getPeerId: true }, (peerId) => {
-      console.log("Peer Id Set? ", Boolean(peerId));
-      if (peerId) {
-        setTimeout(() => {
-          let contentScript = new ContentScript();
-          contentScript.injectVemos(peerId);
-        }, 1000);
+    browser.runtime.sendMessage(
+      { getPeerId: true, host: window.location.host },
+      (peerId) => {
+        console.log("Peer Id Set? ", Boolean(peerId));
+        if (peerId) {
+          setTimeout(() => {
+            let contentScript = new ContentScript();
+            contentScript.injectVemos(peerId);
+          }, 1000);
+        }
       }
-    });
+    );
   } else if (window.VEMOS_PEER_ID) {
     setTimeout(() => {
       console.log("A Peer ID was present, booting Vemos");

--- a/vemos-extension/extension/manifest.json
+++ b/vemos-extension/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Vemos",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Virtual movie nights made easy",
   "manifest_version": 2,
   "background": {
@@ -18,7 +18,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["*://*.vemos.org/connect*"],
+      "matches": ["*://*.vemos.org/connect*", "http://localhost/*"],
       "js": ["permission_check.js"],
       "run_at": "document_start"
     },
@@ -40,7 +40,12 @@
     "48": "icons/48.png",
     "128": "icons/128.png"
   },
-  "permissions": ["tabs", "declarativeContent", "*://*.vemos.org/*"],
+  "permissions": [
+    "tabs",
+    "declarativeContent",
+    "*://*.vemos.org/*",
+    "http://localhost/*"
+  ],
   "optional_permissions": ["http://*/*", "https://*/*"],
   "web_accessible_resources": ["assets/app.css", "assets/app.js"],
   "content_security_policy": "script-src 'self'; object-src 'self'; font-src 'self'; connect-src 'self';"

--- a/vemos-extension/extension/permission_check.js
+++ b/vemos-extension/extension/permission_check.js
@@ -27,9 +27,12 @@ window.addEventListener("message", (event) => {
   let peerId = event.data.setPeerId;
   if (peerId) {
     console.log("Set Peer to ", peerId);
-    browser.runtime.sendMessage({ setPeerId: peerId }, (response) => {
-      console.log("Peer set", response);
-      window.postMessage({ peerSet: response }, "*");
-    });
+    browser.runtime.sendMessage(
+      { setPeerId: peerId, host: event.data.host },
+      (response) => {
+        console.log("Peer set", response);
+        window.postMessage({ peerSet: response }, "*");
+      }
+    );
   }
 });

--- a/vemos-extension/extension/permission_check.js
+++ b/vemos-extension/extension/permission_check.js
@@ -1,17 +1,35 @@
-window.addEventListener('DOMContentLoaded', () => {
+window.addEventListener("DOMContentLoaded", () => {
   console.log("Setting vemos-version");
   let browser = window.browser || window.chrome;
-  window.document.documentElement.setAttribute('vemos-version', browser.runtime.getManifest().version);
-})
+  window.document.documentElement.setAttribute(
+    "vemos-version",
+    browser.runtime.getManifest().version
+  );
+});
 
-window.addEventListener("message", event => {
+window.addEventListener("message", (event) => {
   let browser = window.browser || window.chrome;
   let permissionURL = event.data.permissionURL;
   let request = event.data.request;
   if (permissionURL) {
     browser.runtime.sendMessage({ permissionURL, request }, (response) => {
-      console.log('Permission available?', response.result);
-      window.postMessage({ permissionResult: response.result ? 'available' : 'unavailable' }, '*');
+      console.log("Permission available?", response.result);
+      window.postMessage(
+        { permissionResult: response.result ? "available" : "unavailable" },
+        "*"
+      );
+    });
+  }
+});
+
+window.addEventListener("message", (event) => {
+  let browser = window.browser || window.chrome;
+  let peerId = event.data.setPeerId;
+  if (peerId) {
+    console.log("Set Peer to ", peerId);
+    browser.runtime.sendMessage({ setPeerId: peerId }, (response) => {
+      console.log("Peer set", response);
+      window.postMessage({ peerSet: response }, "*");
     });
   }
 });

--- a/vemos-org/connect.html
+++ b/vemos-org/connect.html
@@ -21,6 +21,68 @@
     </script>
 
     <script>
+      function showError(error) {
+        gtag("event", "action", {
+          event_label: "parsing-error",
+          non_interaction: true,
+        });
+        document.querySelector(".error-section").classList.add("o__visible");
+        document.querySelector(".loading-text").classList.add("o__hidden");
+        console.error(error);
+      }
+
+      function showDestinationNotPresentError() {
+        console.error("Destination not present");
+        gtag("event", "action", {
+          event_label: "rerouting-error",
+          non_interaction: true,
+        });
+        document.querySelector(".error-section").classList.add("o__visible");
+        document.querySelector(".loading-text").classList.add("o__hidden");
+      }
+
+      function showExtensionNotPresentNotice() {
+        console.error("Extension not present");
+        gtag("event", "action", {
+          event_label: "not-installed-error",
+          non_interaction: true,
+        });
+        document.querySelector(".not-installed").classList.add("o__visible");
+        document.querySelector(".loading-text").classList.add("o__hidden");
+      }
+
+      function requestPermissions(url, permissionURL) {
+        document.querySelector(".permission-section").classList.add("o__visible");
+        document.querySelector(".loading-text").classList.add("o__hidden");
+        document.querySelector("#site-name").innerHTML = url.host;
+        document.querySelector("#grant-permissions").addEventListener("click", () => {
+          window.postMessage({ permissionURL, request: true }, "*");
+        });
+      }
+
+      function redirectToDestination(url) {
+        console.log("Redirecting to ", url.toString());
+        gtag("event", "action", {
+          event_label: "rerouting-successfully",
+          non_interaction: true,
+        });
+
+        if (!url.toString("vemos-id")) {
+          console.error("The final URL did not contain a Vemos ID", url.toString());
+          document.querySelector(".error-section").classList.add("o__visible");
+          document.querySelector(".loading-text").classList.add("o__hidden");
+        } else {
+          window.location.href = url.toString();
+        }
+      }
+
+      function parseExtensionVersion(extensionVersionString) {
+        let [major, minor, patch] = extensionVersionString.split(".");
+        let extensionVersionNumber = Number(major) * 1000 + Number(minor) * 100 + Number(patch);
+        console.log("Extension version number", extensionVersionNumber);
+        return extensionVersionNumber;
+      }
+
       window.addEventListener("DOMContentLoaded", (event) => {
         console.log("Loading Vemos Version");
         let queryParamString = window.location.search;
@@ -30,6 +92,8 @@
         console.log("destinationUrl", destinationUrl);
         let extensionVersion = window.document.documentElement.getAttribute("vemos-version");
         if (extensionVersion) {
+          let extensionVersionNumber = parseExtensionVersion(extensionVersion);
+
           let queryParamString = window.location.search;
           let queryParams = new URLSearchParams(queryParamString);
           if (queryParams.get("destination")) {
@@ -42,11 +106,6 @@
               window.addEventListener("message", (event) => {
                 if (event.data.permissionResult) {
                   if (event.data.permissionResult == "available") {
-                    console.log("Redirecting to ", url.toString());
-                    gtag("event", "action", {
-                      event_label: "rerouting-successfully",
-                      non_interaction: true,
-                    });
                     // Some messengers seem to decode the Vemos themselves to do link tracking.
                     // This messes up our own decode logic: it is possible to lose the Vemos ID.
                     // This code attemps to readd any missing keys.
@@ -56,51 +115,32 @@
                         url.searchParams.append(key, queryParams.get(key));
                       });
 
-                    if (!url.toString("vemos-id")) {
-                      console.error("The final URL did not contain a Vemos ID", url.toString());
-                      document.querySelector(".error-section").classList.add("o__visible");
-                      document.querySelector(".loading-text").classList.add("o__hidden");
+                    if (extensionVersionNumber > 5) {
+                      window.addEventListener("message", (event) => {
+                        if (event.data.peerSet) {
+                          url.searchParams.delete("vemos-id");
+                          redirectToDestination(url);
+                        }
+                      });
+                      window.postMessage({ setPeerId: url.searchParams.get("vemos-id") });
                     } else {
-                      window.location.href = url.toString();
+                      redirectToDestination(url);
                     }
                   } else {
-                    document.querySelector(".permission-section").classList.add("o__visible");
-                    document.querySelector(".loading-text").classList.add("o__hidden");
-                    document.querySelector("#site-name").innerHTML = url.host;
-                    document.querySelector("#grant-permissions").addEventListener("click", () => {
-                      window.postMessage({ permissionURL, request: true }, "*");
-                    });
+                    requestPermissions(url, permissionURL);
                   }
                 }
               });
 
-              window.postMessage({ permissionURL, request: false }, "*");
+              window.postMessage({ permissionURL, request: false });
             } catch (error) {
-              gtag("event", "action", {
-                event_label: "parsing-error",
-                non_interaction: true,
-              });
-              document.querySelector(".error-section").classList.add("o__visible");
-              document.querySelector(".loading-text").classList.add("o__hidden");
-              console.error(error);
+              showError(error);
             }
           } else {
-            console.error("Destination not present");
-            gtag("event", "action", {
-              event_label: "rerouting-error",
-              non_interaction: true,
-            });
-            document.querySelector(".error-section").classList.add("o__visible");
-            document.querySelector(".loading-text").classList.add("o__hidden");
+            showDestinationNotPresentError();
           }
         } else {
-          console.error("Extension not present");
-          gtag("event", "action", {
-            event_label: "not-installed-error",
-            non_interaction: true,
-          });
-          document.querySelector(".not-installed").classList.add("o__visible");
-          document.querySelector(".loading-text").classList.add("o__hidden");
+          showExtensionNotPresentNotice();
         }
       });
     </script>

--- a/vemos-org/connect.html
+++ b/vemos-org/connect.html
@@ -122,7 +122,10 @@
                           redirectToDestination(url);
                         }
                       });
-                      window.postMessage({ setPeerId: url.searchParams.get("vemos-id") });
+                      window.postMessage({
+                        setPeerId: url.searchParams.get("vemos-id"),
+                        host: url.host,
+                      });
                     } else {
                       redirectToDestination(url);
                     }


### PR DESCRIPTION
Using a query param to store the peer id is not particularly robust.

This PR changes the approach to use the background script to store the peer id.
On connecting via Vemos.org, the page will decode the query param from the invite URL and send it to the background script. This value will then be present for 60 seconds, so any refreshing shenanigans that happen on the destination site should hopefully not cause this to be lost, but longer term returning to the site should not cause Vemos to erroneously boot.

In the content script, on page load, rather than looking for the Vemos id in the URL, we ask the background script.

Towards https://github.com/nolaneo/vemos/issues/23