### PR TITLE
Keep looking for the video if it doesn't exist on first init

### DIFF
--- a/vemos-extension/app/services/video-sync-service.js
+++ b/vemos-extension/app/services/video-sync-service.js
@@ -1,8 +1,8 @@
 import Service from "@ember/service";
 import { inject as service } from "@ember/service";
 import { timeout } from "ember-concurrency";
-import VideoHandler from '../models/video-handler';
-import NetflixHandler from '../models/netflix-handler';
+import VideoHandler from "../models/video-handler";
+import NetflixHandler from "../models/netflix-handler";
 
 export default class VideoSyncService extends Service {
   @service peerService;
@@ -11,8 +11,6 @@ export default class VideoSyncService extends Service {
   currentHandler = undefined;
 
   async initialize() {
-    // Give the host some time to load their video player
-    await timeout(5000);
     this.currentHandler = new this.handlerClass(
       this.peerService,
       this.parentDomService


### PR DESCRIPTION
Towards https://github.com/nolaneo/vemos/issues/23

There's a MutationObserver that looks for changes in the page and ensures that our video reference still exists. In the case where we never found a video on init, we weren't running this. This meant that slow pages, or pages that inject their video late would never work.

This PR changes the behaviour so that the observer runs when no video is found.