### PR TITLE
Fix some video bugs

### DIFF
--- a/vemos-extension/app/components/mediastream-video.js
+++ b/vemos-extension/app/components/mediastream-video.js
@@ -36,13 +36,12 @@ export default class MediastreamVideoComponent extends Component {
       "setupMediaStream video component. Is hidden:",
       this.args.vemosStream.isHidden
     );
-    if (
-      this.args.vemosStream.displayableStream &&
-      !this.args.vemosStream.isHidden
-    ) {
+    if (this.args.vemosStream.displayableStream) {
       this.video.srcObject = this.args.vemosStream.displayableStream;
       try {
-        await this.video.play();
+        if (this.video.paused) {
+          await this.video.play();
+        }
       } catch (e) {
         if (
           e.message.includes("user didn't interact with the document first")

--- a/vemos-extension/app/services/video-call-service.js
+++ b/vemos-extension/app/services/video-call-service.js
@@ -282,8 +282,21 @@ export default class VideoCallServiceService extends Service {
       .getUserMedia(settings)
       .catch((error) => {
         console.error(error);
+        console.error("Could not generate a Video MediaStream.");
+        return this.getAudioOnlyStream();
+      });
+  }
+
+  async getAudioOnlyStream() {
+    let settings = {
+      audio: true,
+    };
+    return this.parentDomService.window.navigator.mediaDevices
+      .getUserMedia(settings)
+      .catch((error) => {
+        console.error(error);
         console.error(
-          "Could not generate a MediaStream. Returning blank stream"
+          "Could not generate a Audio MediaStream. Returning blank stream"
         );
         return new MediaStream();
       });

--- a/vemos-extension/extension/manifest.json
+++ b/vemos-extension/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Vemos",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Virtual movie nights made easy",
   "manifest_version": 2,
   "background": {


### PR DESCRIPTION
* Fix a bug where if the video object was set as `hidden` (the property we use to show the little avatar thing on the video), we'd skip setting the stream for audio.
* Fix an bug where if a user has no camera, failure to generate a video based MediaStream would mean we don't attempt to get an audio only stream.