### PR TITLE
Add collapse/maximise button to main controls component

### DIFF
--- a/vemos-extension/README.md
+++ b/vemos-extension/README.md
@@ -15,7 +15,7 @@ You will need the following things properly installed on your computer.
 ## Installation
 
 * `git clone <repository-url>` this repository
-* `cd vemos-plugin`
+* `cd vemos-extension`
 * `yarn`
 
 ## Running / Development

--- a/vemos-extension/app/components/controls.hbs
+++ b/vemos-extension/app/components/controls.hbs
@@ -1,3 +1,4 @@
+<MaximizeButton />
 <div class="inline-flex justify-center py-4 controls__button-list">
   {{#if this.playerState.isPaused}}
     <button class="controls__button px-2 py-1 rounded-l" {{on "click" this.play}}>

--- a/vemos-extension/extension/manifest.json
+++ b/vemos-extension/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Vemos",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Virtual movie nights made easy",
   "manifest_version": 2,
   "background": {


### PR DESCRIPTION
Tracking issue for sidebar collapse: https://github.com/nolaneo/vemos/issues/7

Support for collapsing/expanding the sidebar was introduced in https://github.com/nolaneo/vemos/pull/13. But the start page route + components no longer seem to be in use in the main application flows.

Re-using the `<MaximizeButton/>` component in the `<Controls />` component to allow us to expand/collapse the sidebar from any route/stage.

![May-30-2020 19-59-16](https://user-images.githubusercontent.com/5411946/83337047-2102d900-a2b0-11ea-9e82-e71d116df3cf.gif)
