### PR TITLE
Revised camera + mic controls

### DIFF
--- a/vemos-extension/app/components/controls.hbs
+++ b/vemos-extension/app/components/controls.hbs
@@ -11,12 +11,12 @@
     </button>
   {{/if}}
   {{#if this.playerState.isMuted}}
-    <button class="controls__button px-2 py-1 o__off" {{on "click" this.unmuteVolume}}>
+    <button class="controls__button px-2 py-1 o__off rounded-r" {{on "click" this.unmuteVolume}}>
       {{inline-svg "icons/volume_off" class="fill-current"}}
       <Tooltip @content="Unmute video" />
     </button>
   {{else}}
-    <button class="controls__button px-2 py-1 " {{on "click" this.muteVolume}}>
+    <button class="controls__button px-2 py-1 rounded-r" {{on "click" this.muteVolume}}>
       {{inline-svg "icons/volume" class="fill-current"}}
       <Tooltip @content="Mute video" />
     </button>

--- a/vemos-extension/app/components/controls.hbs
+++ b/vemos-extension/app/components/controls.hbs
@@ -21,26 +21,4 @@
       <Tooltip @content="Mute video" />
     </button>
   {{/if}}
-  {{#if this.videoCallService.ownMediaStream.isHidden}}
-    <button class="controls__button px-2 py-1 o__off" {{on "click" this.toggleCamera}}>
-      {{inline-svg "icons/cam_off" class="fill-current"}}
-      <Tooltip @content="Enable your webcam" />
-    </button>
-  {{else}}
-    <button class="controls__button px-2 py-1" {{on "click" this.toggleCamera}}>
-      {{inline-svg "icons/cam" class="fill-current"}}
-      <Tooltip @content="Disable your webcam" />
-    </button>
-  {{/if}}
-  {{#if this.videoCallService.ownMediaStream.isMuted}}
-    <button class="controls__button px-2 py-1 o__off rounded-r" {{on "click" this.toggleMic}}>
-      {{inline-svg "icons/mic_off" class="fill-current"}}
-      <Tooltip @content="Unmute your mic" />
-    </button>
-  {{else}}
-    <button class="controls__button px-2 py-1 rounded-r" {{on "click" this.toggleMic}}>
-      {{inline-svg "icons/mic" class="fill-current"}}
-      <Tooltip @content="Mute your mic" />
-    </button>
-  {{/if}}
 </div>

--- a/vemos-extension/app/components/mediastream-audio-indicator.hbs
+++ b/vemos-extension/app/components/mediastream-audio-indicator.hbs
@@ -4,14 +4,14 @@
   {{did-update this.setupAnalyser @mediaStream}}
 >
   <div class="flex flex-col justify-center">
-    <div class="mediastream__waveform-bar o__small"   style={{this.style}}></div>
+    <div class="mediastream__waveform-bar o__small {{if @isMuted 'o__muted'}}"   style={{this.style}}></div>
   </div>
 
   <div class="flex flex-col justify-center">
-    <div class="mediastream__waveform-bar o__large"   style={{this.style}}></div>
+    <div class="mediastream__waveform-bar o__large {{if @isMuted 'o__muted'}}"   style={{this.style}}></div>
   </div>
 
   <div class="flex flex-col justify-center">
-    <div class="mediastream__waveform-bar o__small"   style={{this.style}}></div>
+    <div class="mediastream__waveform-bar o__small {{if @isMuted 'o__muted'}}"   style={{this.style}}></div>
   </div>
 </div>

--- a/vemos-extension/app/components/mediastream-video.hbs
+++ b/vemos-extension/app/components/mediastream-video.hbs
@@ -50,7 +50,7 @@
           {{/if}}
         </div>
       {{/if}}
-      <MediastreamAudioIndicator @mediaStream={{@vemosStream.audioStream}} />
+      <MediastreamAudioIndicator @mediaStream={{@vemosStream.audioStream}} @isMuted={{@vemosStream.isMuted}} />
     {{/unless}}
   {{/if}}
 

--- a/vemos-extension/app/components/mediastream-video.hbs
+++ b/vemos-extension/app/components/mediastream-video.hbs
@@ -18,7 +18,7 @@
     {{#unless this.showClickToPlayOverlay}}
       {{#if @vemosStream.isOwnStream}}
         {{#if @vemosStream.isHidden}}
-          <button class="mediastream-controls o__ownstream-controls o__hidden mr-10" {{on "click" (fn this.toggleCamera @vemosStream)}}>
+          <button class="mediastream-controls o__ownstream-controls mr-10" {{on "click" (fn this.toggleCamera @vemosStream)}}>
             {{inline-svg "icons/cam_off" class="fill-current"}}
             <Tooltip @content="Enable your webcam" />
           </button>
@@ -29,7 +29,7 @@
           </button>
         {{/if}}
         {{#if @vemosStream.isMuted}}
-          <button class="mediastream-controls o__ownstream-controls o__muted" {{on "click" (fn this.toggleMic @vemosStream)}}>
+          <button class="mediastream-controls o__ownstream-controls" {{on "click" (fn this.toggleMic @vemosStream)}}>
             {{inline-svg "icons/mic_off" class="fill-current"}}
             <Tooltip @content="Unmute your mic" />
           </button>

--- a/vemos-extension/app/components/mediastream-video.hbs
+++ b/vemos-extension/app/components/mediastream-video.hbs
@@ -16,7 +16,30 @@
     {{/if}}
 
     {{#unless this.showClickToPlayOverlay}}
-      {{#unless @vemosStream.isOwnStream}}
+      {{#if @vemosStream.isOwnStream}}
+        {{#if @vemosStream.isHidden}}
+          <button class="controls__button px-2 py-1 o__off" {{on "click" (fn this.toggleCamera @vemosStream)}}>
+            {{inline-svg "icons/cam_off" class="fill-current"}}
+            <Tooltip @content="Enable your webcam" />
+          </button>
+        {{else}}
+          <button class="controls__button px-2 py-1" {{on "click" (fn this.toggleCamera @vemosStream)}}>
+            {{inline-svg "icons/cam" class="fill-current"}}
+            <Tooltip @content="Disable your webcam" />
+          </button>
+        {{/if}}
+        {{#if @vemosStream.isMuted}}
+          <button class="controls__button px-2 py-1 o__off rounded-r" {{on "click" (fn this.toggleMic @vemosStream)}}>
+            {{inline-svg "icons/mic_off" class="fill-current"}}
+            <Tooltip @content="Unmute your mic" />
+          </button>
+        {{else}}
+          <button class="controls__button px-2 py-1 rounded-r" {{on "click" (fn this.toggleMic @vemosStream)}}>
+            {{inline-svg "icons/mic" class="fill-current"}}
+            <Tooltip @content="Mute your mic" />
+          </button>
+        {{/if}}
+      {{else}}
         <div class="mediastream-controls o__audio-controls {{if @vemosStream.isMuted 'o__muted'}}" role="button" {{on "click" this.toggleAudio}}>
           {{#if @vemosStream.isMuted}}
             {{inline-svg 'icons/volume_off'}}
@@ -26,7 +49,7 @@
             <Tooltip @content={{"Mute this person."}} />
           {{/if}}
         </div>
-      {{/unless}}
+      {{/if}}
       <MediastreamAudioIndicator @mediaStream={{@vemosStream.audioStream}} />
     {{/unless}}
   {{/if}}

--- a/vemos-extension/app/components/mediastream-video.hbs
+++ b/vemos-extension/app/components/mediastream-video.hbs
@@ -18,23 +18,23 @@
     {{#unless this.showClickToPlayOverlay}}
       {{#if @vemosStream.isOwnStream}}
         {{#if @vemosStream.isHidden}}
-          <button class="controls__button px-2 py-1 o__off" {{on "click" (fn this.toggleCamera @vemosStream)}}>
+          <button class="mediastream-controls o__ownstream-controls o__hidden mr-10" {{on "click" (fn this.toggleCamera @vemosStream)}}>
             {{inline-svg "icons/cam_off" class="fill-current"}}
             <Tooltip @content="Enable your webcam" />
           </button>
         {{else}}
-          <button class="controls__button px-2 py-1" {{on "click" (fn this.toggleCamera @vemosStream)}}>
+          <button class="mediastream-controls o__ownstream-controls mr-10" {{on "click" (fn this.toggleCamera @vemosStream)}}>
             {{inline-svg "icons/cam" class="fill-current"}}
             <Tooltip @content="Disable your webcam" />
           </button>
         {{/if}}
         {{#if @vemosStream.isMuted}}
-          <button class="controls__button px-2 py-1 o__off rounded-r" {{on "click" (fn this.toggleMic @vemosStream)}}>
+          <button class="mediastream-controls o__ownstream-controls o__muted" {{on "click" (fn this.toggleMic @vemosStream)}}>
             {{inline-svg "icons/mic_off" class="fill-current"}}
             <Tooltip @content="Unmute your mic" />
           </button>
         {{else}}
-          <button class="controls__button px-2 py-1 rounded-r" {{on "click" (fn this.toggleMic @vemosStream)}}>
+          <button class="mediastream-controls o__ownstream-controls" {{on "click" (fn this.toggleMic @vemosStream)}}>
             {{inline-svg "icons/mic" class="fill-current"}}
             <Tooltip @content="Mute your mic" />
           </button>

--- a/vemos-extension/app/components/mediastream-video.js
+++ b/vemos-extension/app/components/mediastream-video.js
@@ -31,6 +31,16 @@ export default class MediastreamVideoComponent extends Component {
     }
   }
 
+  @action toggleCamera(videoStream) {
+    this.metricsService.recordMetric("controls-toggle-camera");
+    videoStream.toggleVideo();
+  }
+
+  @action toggleMic(videoStream) {
+    this.metricsService.recordMetric("controls-toggle-mic");
+    videoStream.toggleAudio();
+  }
+
   async setStreamSource() {
     console.log(
       "setupMediaStream video component. Is hidden:",

--- a/vemos-extension/app/styles/_mediastream.scss
+++ b/vemos-extension/app/styles/_mediastream.scss
@@ -36,7 +36,6 @@
 
 .mediastream-controls.o__ownstream-controls {
   opacity: 1;
-  background-color: rgba(12, 12, 12, 0.5);
   bottom: 5px;
   right: 5px;
 }

--- a/vemos-extension/app/styles/_mediastream.scss
+++ b/vemos-extension/app/styles/_mediastream.scss
@@ -12,7 +12,7 @@
 }
 
 .mediastream-container:hover .mediastream-controls,
-.mediastream-controls.o__muted, .mediastream-controls.o__hidden {
+.mediastream-controls.o__muted {
   opacity: 1;
 }
 
@@ -35,6 +35,7 @@
 }
 
 .mediastream-controls.o__ownstream-controls {
+  opacity: 1;
   background-color: rgba(12, 12, 12, 0.5);
   bottom: 5px;
   right: 5px;

--- a/vemos-extension/app/styles/_mediastream.scss
+++ b/vemos-extension/app/styles/_mediastream.scss
@@ -12,7 +12,7 @@
 }
 
 .mediastream-container:hover .mediastream-controls,
-.mediastream-controls.o__muted {
+.mediastream-controls.o__muted, .mediastream-controls.o__hidden {
   opacity: 1;
 }
 
@@ -32,6 +32,12 @@
     fill: white;
     opacity: 0.8;
   }
+}
+
+.mediastream-controls.o__ownstream-controls {
+  background-color: rgba(12, 12, 12, 0.5);
+  bottom: 5px;
+  right: 5px;
 }
 
 .mediastream-controls.o__audio-controls {

--- a/vemos-extension/app/styles/_mediastream.scss
+++ b/vemos-extension/app/styles/_mediastream.scss
@@ -74,6 +74,11 @@
   opacity: 0.9;
 }
 
+.mediastream__waveform-bar.o__muted {
+  background-color: #c70000;
+  border: 1px solid #c70000;
+}
+
 .mediastream__waveform-bar.o__small {
   max-height: 75%;
   height: calc(var(--height) / 2);


### PR DESCRIPTION
### Summary
Proposal for more intuitive personal camera + mic controls. Thought of giving this a try as I familiarise myself with the codebase! The current design has the page video + personal controls grouped into the same toolbar, which can be tricky for first time users.

Main page video controls stay in the toolbar at the top. Moving the camera + mic controls. Adapting the style/approach from popular meeting/conferencing apps to overlay the camera & mic controls on top of the preview tile. Muting the mic will also flip the audio level indicator to red to make it clearer that the mic has been muted.

### Existing controls
![image](https://user-images.githubusercontent.com/5411946/83340730-b5cafe00-a2d3-11ea-92dc-7c4ab062c933.png)

### New controls
![new controls](https://user-images.githubusercontent.com/5411946/83340766-14907780-a2d4-11ea-9029-68f875311c1f.gif)
